### PR TITLE
Use supplemental-ui to configure the header

### DIFF
--- a/antora/supplemental-ui/_headers
+++ b/antora/supplemental-ui/_headers
@@ -1,0 +1,4 @@
+# We could switch to /_/* and use an indefinite age if we append a cache buster to all asset URLs
+/_/font/*
+  Cache-Control: public,max-age=604800
+

--- a/antora/supplemental-ui/partials/header-content.hbs
+++ b/antora/supplemental-ui/partials/header-content.hbs
@@ -1,0 +1,25 @@
+<header class="header" role="banner">
+  <nav class="navbar">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}">{{site.title}}</a>
+      <button class="navbar-burger" data-target="topbar-nav">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+    <div id="topbar-nav" class="navbar-menu">
+      <div class="navbar-end">
+        <a class="navbar-item" href="https://github.com/asciidoctor/asciidoctor">
+          Repository
+        </a>
+        <a class="navbar-item" href="https://github.com/asciidoctor/asciidoctor/issues">
+          Issue Tracker
+        </a>
+        <a class="navbar-item" href="https://gitter.im/asciidoctor/asciidoctor">
+          Chat
+        </a>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/antora/supplemental-ui/robots.txt
+++ b/antora/supplemental-ui/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+

--- a/antora/supplemental-ui/ui.yml
+++ b/antora/supplemental-ui/ui.yml
@@ -1,0 +1,3 @@
+staticFiles:
+- _headers
+- robots.txt

--- a/site.yml
+++ b/site.yml
@@ -53,6 +53,6 @@ ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
     snapshot: true
-#  supplemental_files: ./supplemental-ui
+  supplemental_files: ./antora/supplemental-ui
 output:
   dir: ./public


### PR DESCRIPTION
It could be nice to have a dedicated header per module (so we could contextualize the links) but until then I've replaced the default header with links on the Asciidoctor repository (GitHub), Issue tracker (GitHub) and Chat (Gitter).