### PR TITLE
Enable search on Asciidoctor.js, Asciidoctor reveal.js and Maven tools components

### DIFF
--- a/docsearch/config.json
+++ b/docsearch/config.json
@@ -20,6 +20,39 @@
           "latest"
         ]
       }
+    },
+    {
+      "url": "https://asciidoctor-docs.netlify.app/(?P<component>.*?)/(?P<version>.*?)/",
+      "variables": {
+        "component": [
+          "asciidoctor.js"
+        ],
+        "version": [
+          "latest"
+        ]
+      }
+    },
+    {
+      "url": "https://asciidoctor-docs.netlify.app/(?P<component>.*?)/(?P<version>.*?)/",
+      "variables": {
+        "component": [
+          "reveal.js-converter"
+        ],
+        "version": [
+          "latest"
+        ]
+      }
+    },
+    {
+      "url": "https://asciidoctor-docs.netlify.app/(?P<component>.*?)/(?P<version>.*?)/",
+      "variables": {
+        "component": [
+          "maven-tools"
+        ],
+        "version": [
+          "latest"
+        ]
+      }
     }
   ],
   "sitemap_urls": [


### PR DESCRIPTION
I think the logic is to duplicate the configuration block for each component, right?
And when we publish a new version, we will add the _previous_ version in the `version` list. So if we publish Asciidoctor 2.1, we will add version `2.0` in the `version` list for the `asciidoctor` component, correct?