### PR TITLE
Publish the 2.2 documentation for Asciidoctor.js

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -18,7 +18,7 @@ content:
     branches: issue-3861-import-docs
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor.js
-    branches: master
+    branches: 'v2.2.x'
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-cli.js
     branches: master


### PR DESCRIPTION
Version 3.0 is not yet released (master).