### PR TITLE
Set fixed Asciidoctorj to avoid publishing unreleased changes

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -28,7 +28,7 @@ content:
     branches: master
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctorj
-    branches: main
+    branches: v2.4.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
     branches: main


### PR DESCRIPTION
Recently we updated the docs according to some code changes and those changes went life in the docs.
However, those changes are new methods so that makes the docs invalid and already one user was confused.
This PR updates the configuration to point to the latest stable to avoid this problem. On new releases we will have to update the tag to the latest stable branch, or create a fixed "latest" branch in the repo.

Now, I am not sure about this change. Seems to me we should not be the first to encounter this issue, however, I see all configuration in the playbook uses main branches. I am  understanding something wrong?