### PR TITLE
Take AsciidoctorJ 2.5.x docs from maintenance branch

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -34,7 +34,7 @@ content:
     branches: main
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctorj
-    branches: main, v2.4.x
+    branches: v2.5.x, v2.4.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
     branches: main


### PR DESCRIPTION
AsciidoctorJ has a maintenance branch 2.5.x now. Main will soonish receive breaking changes.
Therefore docs.asciidoctor.org should pull the docs for AsciidoctorJ 2.5.x from that branch instead of main.
Main should be added back once the next major release has been published. 