### PR TITLE
Point Asciidoctor Maven Plugin docs to branch v2.2.x

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -37,7 +37,7 @@ content:
     branches: v2.5.x, v2.4.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
-    branches: main
+    branches: v2.2.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoclet
     branches: master


### PR DESCRIPTION
[Sailing toward v3](https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/595) of the plugin it has big changes that affect the docs, so we cannot keep using main for current release.

I have created branch v2.2.x with latest docs fixes.
