### PR TITLE
Adds asciidoctor-browser-extension

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -56,6 +56,9 @@ content:
   - url: https://github.com/asciidoctor/asciidoctor-diagram
     branches: release
     start_path: docs
+  - url: https://github.com/sturtison/asciidoctor-browser-extension
+    branches: docs/issue-648-refresh-docs-draft
+    start_path: docs
 asciidoc:
   attributes:
     page-component-order: '!home, !ROOT, *, asciidoclet, reveal.js-converter, pdf-converter, epub3-converter, diagram-extension, about'


### PR DESCRIPTION
Currently using sturtison fork. The goal is to get a preview of how the Asciidoctor Browser Extension documentation looks.