### PR TITLE
Add Asciidoctorj 'main' branch to publish v3 alpha docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -36,7 +36,7 @@ content:
     branches: main
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctorj
-    branches: v2.5.x, v2.4.x
+    branches: main, v2.5.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
     branches: v2.2.x

--- a/netlify/netlify.toml
+++ b/netlify/netlify.toml
@@ -63,3 +63,9 @@ from = "/asciidoctor.js"
 to = "/asciidoctor.js/latest/"
 status = 301
 force = true
+
+[[redirects]]
+from = "/asciidoctorj/2.4/*"
+to = "/asciidoctorj/latest/"
+status = 301
+force = true


### PR DESCRIPTION
V3 has breaking changes and the docs include step-by-step migration guides to help users.
I think it's fair to publish them, noting it's an alpha. For that reason, the Antora metadata in AsciidoctorJ uses `prerelease` property.

Also, remove v2.4.x branch which is no longer maintained