### PR TITLE
Publish asciidoctor-maven-plugin v3.0.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -42,7 +42,7 @@ content:
     branches: main
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
-    branches: v2.2.x
+    branches: main, v2.2.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoclet
     branches: master


### PR DESCRIPTION
Last step for v3.0.0 release.

@mojavelinux don't merge yet, I have a question. This gets published as soon as merged or is still nightly iirc?