### PR TITLE
Publish Asciidoctlet v1.5.x maintenance branch docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -45,7 +45,7 @@ content:
     branches: main, v2.2.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoclet
-    branches: master
+    branches: v1.5.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-reveal.js
     branches: 5.0.x, maint-4.1.x


### PR DESCRIPTION
To prevent changes in `main` branch for being published before time.

ref: https://github.com/asciidoctor/asciidoclet/issues/110