### PR TITLE
Integrate asciidoctor-tabs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -64,6 +64,8 @@ content:
     branches: release
     start_path: docs
 asciidoc:
+  extensions:
+    - '@asciidoctor/tabs'
   attributes:
     page-component-order: '!ROOT, *, pdf-converter, epub3-converter, reveal.js-converter, maven-tools, gradle-plugin, asciidoclet, diagram-extension, browser-extension, about'
     page-pagination: ''

--- a/netlify/package.json
+++ b/netlify/package.json
@@ -3,6 +3,7 @@
   "description": "Asciidoctor Docs (Production and Deploy Previews)",
   "private": true,
   "devDependencies": {
+    "@asciidoctor/tabs": "1.0.0-beta.6",
     "antora": "3.1.8",
     "netlify-plugin-checklinks": "git+https://github.com/mojavelinux/netlify-plugin-checklinks.git#patched"
   },


### PR DESCRIPTION
Integrate https://github.com/asciidoctor/asciidoctor-tabs to support tabs.
The need arose when wanting to document asciidoctlet configuration for Gradle in both Groovy and Kotlin.

Take this PR as a starting point, I followed instructions in https://github.com/asciidoctor/asciidoctor-tabs/blob/main/docs/use-with-antora.adoc, and it is working fine locally. But I would like to confirm the approach, do we prefer to modify the UI theme or embed the modifications directly here? I prefer having them all together in the same repo.

*IMPORTANT*: I updated `netlify.toml` based on what makes sense to me but I am nor familiar and 100% sure that will work. How can we check?