### PR TITLE
Remove asciidoctor-maven-plugin v2.2.x docs (version EOS)

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -46,7 +46,7 @@ content:
     branches: master
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
-    branches: main, v2.2.x
+    branches: main
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoclet
     branches: main, v1.5.x


### PR DESCRIPTION
Only v3.x.x versions are supported now.