### PR TITLE
Add 5.x asciidoctor-gradle

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -43,7 +43,7 @@ content:
     branches: main
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-gradle-plugin
-    branches: master
+    branches: master, development-5.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-maven-plugin
     branches: main


### PR DESCRIPTION
Adds the development-5.x page whilst the 5..0.0 alpha versions are being released.

In the future we'll remove development-5.x and replace it with maintenance-4.x because at that point 5.x will be on the main branch.