### PR TITLE
publish Asciidoctor.js 4.0.x documentation

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -31,7 +31,7 @@ content:
     branches: v2.0.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor.js
-    branches: 3.0.x, v2.2.x
+    branches: main, 3.0.x, v2.2.x
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-cli.js
     branches: main


### PR DESCRIPTION
The next version of Asciidoctor.js, currently on the main branch, includes breaking changes. To prepare for the migration from version 3.x to version 4.x, I think it would be useful to publish the documentation for version 4.0.x (which is configured with `prerelease: true`).

https://github.com/asciidoctor/asciidoctor.js/blob/5168afc184f3c5c4c0e958c6321d817645b6e555/docs/antora.yml

This will allow us to gather user feedback and improve the migration guide before releasing the "final" 4.0.0 version.