### PR TITLE
use main branch for asciidoctor-kroki

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -64,7 +64,7 @@ content:
     branches: release
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-kroki
-    branches: master
+    branches: main
     start_path: docs
   - url: https://github.com/asciidoctor/asciidoctor-vscode
     branches: main


### PR DESCRIPTION
The default branch of asciidoctor-kroki was renamed from `master` to `main`, so the Antora playbook must reference the new branch name.